### PR TITLE
Implement placeholder texture to be used when a texture fails to load

### DIFF
--- a/include/ResourceManager.h
+++ b/include/ResourceManager.h
@@ -14,8 +14,7 @@ namespace tjg {
 
     class ResourceManager {
     private:
-        // Returned when a texture fails to load
-        std::shared_ptr<sf::Texture> placeholder_texture;
+        const std::string placeholder = "PLACEHOLDER";
 
         template<typename T>
         using ResourceMap = std::unordered_map<std::string, std::shared_ptr<T>>;
@@ -34,8 +33,7 @@ namespace tjg {
                 auto success = map[path]->loadFromFile(path);
                 if (!success) {
                     std::cout << path << " not found." << std::endl;
-                    return nullptr;
-                    throw std::runtime_error(path + std::string(" not found"));
+                    return map[placeholder];
                 }
                 std::cout << "done." << std::endl;
             }

--- a/include/ResourceManager.h
+++ b/include/ResourceManager.h
@@ -14,6 +14,8 @@ namespace tjg {
 
     class ResourceManager {
     private:
+        // Returned when a texture fails to load
+        std::shared_ptr<sf::Texture> placeholder_texture;
 
         template<typename T>
         using ResourceMap = std::unordered_map<std::string, std::shared_ptr<T>>;
@@ -31,6 +33,8 @@ namespace tjg {
                 std::cout << "Loading " << path << "...";
                 auto success = map[path]->loadFromFile(path);
                 if (!success) {
+                    std::cout << path << " not found." << std::endl;
+                    return nullptr;
                     throw std::runtime_error(path + std::string(" not found"));
                 }
                 std::cout << "done." << std::endl;
@@ -48,8 +52,7 @@ namespace tjg {
 
     public:
         // Constructors
-        ResourceManager() = default;
-        explicit ResourceManager(const std::string &resource_root);
+        explicit ResourceManager(const std::string &resource_root = "");
         // Resource loading
         std::shared_ptr<sf::Font> LoadFont(const std::string &filename);
         std::shared_ptr<sf::Texture> LoadTexture(const std::string &filename);

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -5,6 +5,22 @@ namespace tjg {
  * @param resource_root Path to resources root folder
  */
     ResourceManager::ResourceManager(const std::string &resource_root) {
+
+        // Generate placeholder image with checkerboard pattern
+        sf::Image placeholder_image;
+        placeholder_image.create(8, 8, sf::Color::Red);
+        for (int x = 0; x < 4; x++) {
+            for (int y = 0; y < 4; y++) {
+                placeholder_image.setPixel(x, y, sf::Color::White);
+                placeholder_image.setPixel(x + 4, y + 4, sf::Color::Blue);
+            }
+        }
+
+        // Load the placeholder texture from the placeholder image generated above.
+        placeholder_texture = std::make_shared<sf::Texture>();
+        placeholder_texture->loadFromImage(placeholder_image);
+        placeholder_texture->setRepeated(true);
+
         this->resource_root = resource_root;
     }
 
@@ -23,7 +39,12 @@ namespace tjg {
  * @return pointer to the Texture
  */
     std::shared_ptr<sf::Texture> ResourceManager::LoadTexture(const std::string &filename) {
-        return load(textures, filename);
+        auto texture = load(textures, filename);
+        if (texture == nullptr) {
+            return placeholder_texture;
+        }
+        texture->setSmooth(true);
+        return texture;
     }
 
 /**

--- a/src/ResourceManager.cpp
+++ b/src/ResourceManager.cpp
@@ -17,9 +17,13 @@ namespace tjg {
         }
 
         // Load the placeholder texture from the placeholder image generated above.
-        placeholder_texture = std::make_shared<sf::Texture>();
-        placeholder_texture->loadFromImage(placeholder_image);
-        placeholder_texture->setRepeated(true);
+        textures[placeholder] = std::make_shared<sf::Texture>();
+        textures[placeholder]->loadFromImage(placeholder_image);
+        textures[placeholder]->setRepeated(true);
+
+        sounds[placeholder] = std::make_shared<sf::SoundBuffer>();
+
+        fonts[placeholder] = std::make_shared<sf::Font>();
 
         this->resource_root = resource_root;
     }
@@ -39,12 +43,7 @@ namespace tjg {
  * @return pointer to the Texture
  */
     std::shared_ptr<sf::Texture> ResourceManager::LoadTexture(const std::string &filename) {
-        auto texture = load(textures, filename);
-        if (texture == nullptr) {
-            return placeholder_texture;
-        }
-        texture->setSmooth(true);
-        return texture;
+        return load(textures, filename);
     }
 
 /**


### PR DESCRIPTION
I made the ResourceManager generate a little checkerboard texture and return it when a texture fails to load. For the sounds/fonts it just uses an empty sound/font so the only indication of the failure will be a message displayed in the console output. I this resolves #11.

