### PR TITLE
Implement a collision center

### DIFF
--- a/include/CollisionCenter.h
+++ b/include/CollisionCenter.h
@@ -1,0 +1,33 @@
+
+#ifndef GAME_COLLISIONCENTER_H
+#define GAME_COLLISIONCENTER_H
+
+#include <functional>
+#include <vector>
+
+#include <chipmunk.h>
+
+
+namespace tjg {
+
+    // Used to identify collision types involved in a collision
+    enum class CollisionGroup : cpCollisionType {
+        DEFAULT = 0,
+        TECH17,
+        WALL,
+        EXIT
+    };
+
+    class CollisionCenter {
+    private:
+        cpSpace *space;
+        std::vector<std::pair<cpCollisionHandler *, std::function<cpBool(cpArbiter *arb, cpSpace *space)>>> handlers;
+
+    public:
+        explicit CollisionCenter(cpSpace* space) : space(space) {};
+        void AddHandler(CollisionGroup, CollisionGroup, std::function<cpBool(cpArbiter *arb, cpSpace *space)> callback);
+    };
+
+}
+
+#endif //GAME_COLLISIONCENTER_H

--- a/include/EntityFactory.h
+++ b/include/EntityFactory.h
@@ -10,7 +10,7 @@
 #include "ResourceManager.h"
 
 #include "EventManager.h"
-#include "Events/ExitReached.h"
+#include "Events/ReachedExit.h"
 
 #include "Components/Appendage.h"
 #include "Components/DynamicBody.h"

--- a/include/Events/HitWall.h
+++ b/include/Events/HitWall.h
@@ -1,0 +1,16 @@
+
+#ifndef GAME_HITWALL_H
+#define GAME_HITWALL_H
+
+#include "Event.h"
+
+namespace tjg {
+    class HitWall : public Event {
+    private:
+        //  - time elapsed
+    public:
+        explicit HitWall();
+    };
+}
+
+#endif //GAME_HITWALL_H

--- a/include/Events/ReachedExit.h
+++ b/include/Events/ReachedExit.h
@@ -1,18 +1,18 @@
 
-#ifndef GAME_EXITREACHED_H
-#define GAME_EXITREACHED_H
+#ifndef GAME_REACHEDEXIT_H
+#define GAME_REACHEDEXIT_H
 
 #include "Event.h"
 
 namespace tjg {
-    class ExitReached : public Event {
+    class ReachedExit : public Event {
     private:
         // could possible contain information such as:
         //  - time elapsed
         //  - fuel remaining
     public:
-        explicit ExitReached();
+        explicit ReachedExit();
     };
 }
 
-#endif //GAME_EXITREACHED_H
+#endif //GAME_REACHEDEXIT_H

--- a/include/Systems/PhysicsSystem.h
+++ b/include/Systems/PhysicsSystem.h
@@ -7,19 +7,24 @@
     #define M_PI 3.14159265358979323846
 #endif
 
+#include <iostream>
+
 #include <chipmunk.h>
 #include <SFML/System/Time.hpp>
+
+#include "CollisionCenter.h"
 
 #include "Components/DynamicBody.h"
 #include "Components/LinearForce.h"
 #include "Components/SensorShape.h"
 
 #include "EventManager.h"
-#include "Events/ExitReached.h"
+#include "Events/HitWall.h"
 
 #include "System.h"
 
 namespace tjg {
+
     class PhysicsSystem : public System {
     private:
         cpSpace* space;
@@ -27,18 +32,13 @@ namespace tjg {
 
         std::vector<std::shared_ptr<Entity>> entities;
 
+        CollisionCenter collision_center;
+
     public:
         // Constructor
         PhysicsSystem(EventManager &event_manager);
         // Destructor
         ~PhysicsSystem();
-
-        enum class CollisionGroup : cpCollisionType {
-            DEFAULT = 0,
-            TECH17,
-            WALL,
-            EXIT
-        };
 
         /**
          * Add an entity to be simulated. Requires DynamicBody and Location components to be present

--- a/include/Systems/PhysicsSystem.h
+++ b/include/Systems/PhysicsSystem.h
@@ -29,7 +29,8 @@ namespace tjg {
 
         enum class CollisionGroup : cpCollisionType {
             DEFAULT = 0,
-            TECH17_CHEST,
+            TECH17,
+            WALL,
             EXIT
         };
 

--- a/include/Systems/PhysicsSystem.h
+++ b/include/Systems/PhysicsSystem.h
@@ -13,17 +13,23 @@
 #include "Components/DynamicBody.h"
 #include "Components/LinearForce.h"
 #include "Components/SensorShape.h"
+
+#include "EventManager.h"
+#include "Events/ExitReached.h"
+
 #include "System.h"
 
 namespace tjg {
     class PhysicsSystem : public System {
     private:
         cpSpace* space;
+        EventManager &event_manager;
+
         std::vector<std::shared_ptr<Entity>> entities;
 
     public:
         // Constructor
-        PhysicsSystem();
+        PhysicsSystem(EventManager &event_manager);
         // Destructor
         ~PhysicsSystem();
 

--- a/include/View.h
+++ b/include/View.h
@@ -8,7 +8,7 @@
 #include "Systems/ControlCenter.h"
 #include "EntityFactory.h"
 #include "EventManager.h"
-#include "Events/ExitReached.h"
+#include "Events/ReachedExit.h"
 
 namespace tjg {
 
@@ -17,12 +17,13 @@ namespace tjg {
         virtual void initialize() = 0;
         virtual void update() = 0;
     protected:
+        ResourceManager &resource_manager;
+
         // Systems
         // All views need a physical center and control center.
         PhysicsSystem physics_system;
         ControlCenter control_center;
 
-        ResourceManager &resource_manager;
         EntityFactory entity_factory;
         EventManager event_manager;
 

--- a/src/CollisionCenter.cpp
+++ b/src/CollisionCenter.cpp
@@ -1,0 +1,22 @@
+#include "CollisionCenter.h"
+
+namespace tjg {
+    void CollisionCenter::AddHandler(CollisionGroup group1, CollisionGroup group2,
+                                     std::function<cpBool(cpArbiter *arb, cpSpace *space)> callback) {
+
+        auto handler = cpSpaceAddCollisionHandler(
+            space,
+            static_cast<cpCollisionType>(group1),
+            static_cast<cpCollisionType>(group2)
+        );
+
+        handlers.emplace_back(std::pair<cpCollisionHandler*, std::function<cpBool(cpArbiter *, cpSpace *)>>(
+                handler, std::move(callback)
+        ));
+        handler->userData = &handlers.back().second;
+        handler->beginFunc = [](cpArbiter *arb, struct cpSpace *space, cpDataPointer f) -> cpBool {
+            return (*static_cast<std::function<cpBool (cpArbiter*, cpSpace*)>*>(f))(arb, space);
+        };
+
+    }
+}

--- a/src/EntityFactory.cpp
+++ b/src/EntityFactory.cpp
@@ -12,7 +12,7 @@ namespace tjg {
 
         // Add static segment component
         auto static_segment = wall->AddComponent<StaticSegment>(physics_system.GetSpace(), a.x, a.y, b.x, b.y, width);
-        cpShapeSetCollisionType(static_segment->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::WALL));
+        cpShapeSetCollisionType(static_segment->GetShape(), static_cast<cpCollisionType>(CollisionGroup::WALL));
 
         // Load wall texture.
         auto wall_texture = resource_manager.LoadTexture("wall-texture.png"); // TODO get a real wall texture
@@ -122,7 +122,7 @@ namespace tjg {
                 sf::Vector2f(0, 0),
                 1,
                 sf::Vector2f(CHEST_WIDTH, CHEST_HEIGHT));
-        cpShapeSetCollisionType(torso_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
+        cpShapeSetCollisionType(torso_body->GetShape(), static_cast<cpCollisionType>(CollisionGroup::TECH17));
         physics_system.AddEntity(tech17);
 
         //
@@ -151,7 +151,7 @@ namespace tjg {
                 LIMB_STIFFNESS * 10.0f,
                 0.0f,
                 LIMB_ROTATION_LIMIT);
-        cpShapeSetCollisionType(abs_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
+        cpShapeSetCollisionType(abs_body->GetShape(), static_cast<cpCollisionType>(CollisionGroup::TECH17));
         physics_system.AddEntity(abs_entity);
         tech17->AddChild(abs_entity);
 
@@ -181,7 +181,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 0.0f,
                 LIMB_ROTATION_LIMIT);
-        cpShapeSetCollisionType(head_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
+        cpShapeSetCollisionType(head_body->GetShape(), static_cast<cpCollisionType>(CollisionGroup::TECH17));
         physics_system.AddEntity(head_entity);
         tech17->AddChild(head_entity);
 
@@ -214,7 +214,7 @@ namespace tjg {
                 // Set the angle to keep the arm at his side.
                 -1 * ARM_ANGLE,
                 LIMB_ROTATION_LIMIT);
-        cpShapeSetCollisionType(left_bicep_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
+        cpShapeSetCollisionType(left_bicep_body->GetShape(), static_cast<cpCollisionType>(CollisionGroup::TECH17));
         physics_system.AddEntity(left_bicep_entity);
         tech17->AddChild(left_bicep_entity);
 
@@ -240,7 +240,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 ARM_ANGLE,
                 LIMB_ROTATION_LIMIT);
-        cpShapeSetCollisionType(right_bicep_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
+        cpShapeSetCollisionType(right_bicep_body->GetShape(), static_cast<cpCollisionType>(CollisionGroup::TECH17));
         physics_system.AddEntity(right_bicep_entity);
         tech17->AddChild(right_bicep_entity);
 
@@ -272,7 +272,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 -1 * ARM_ANGLE / 2.0f,
                 LIMB_ROTATION_LIMIT);
-        cpShapeSetCollisionType(left_forearm_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
+        cpShapeSetCollisionType(left_forearm_body->GetShape(), static_cast<cpCollisionType>(CollisionGroup::TECH17));
         physics_system.AddEntity(left_forearm_entity);
         tech17->AddChild(left_forearm_entity);
 
@@ -298,7 +298,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 ARM_ANGLE / 2.0f,
                 LIMB_ROTATION_LIMIT);
-        cpShapeSetCollisionType(right_forearm_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
+        cpShapeSetCollisionType(right_forearm_body->GetShape(), static_cast<cpCollisionType>(CollisionGroup::TECH17));
         physics_system.AddEntity(right_forearm_entity);
         tech17->AddChild(right_forearm_entity);
 
@@ -329,7 +329,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 0.0f,
                 LIMB_ROTATION_LIMIT);
-        cpShapeSetCollisionType(left_thigh_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
+        cpShapeSetCollisionType(left_thigh_body->GetShape(), static_cast<cpCollisionType>(CollisionGroup::TECH17));
         physics_system.AddEntity(left_thigh_entity);
         tech17->AddChild(left_thigh_entity);
 
@@ -355,7 +355,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 0.0f,
                 LIMB_ROTATION_LIMIT);
-        cpShapeSetCollisionType(right_thigh_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
+        cpShapeSetCollisionType(right_thigh_body->GetShape(), static_cast<cpCollisionType>(CollisionGroup::TECH17));
         physics_system.AddEntity(right_thigh_entity);
         tech17->AddChild(right_thigh_entity);
 
@@ -387,7 +387,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 0.0f,
                 LIMB_ROTATION_LIMIT);
-        cpShapeSetCollisionType(left_shin_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
+        cpShapeSetCollisionType(left_shin_body->GetShape(), static_cast<cpCollisionType>(CollisionGroup::TECH17));
         physics_system.AddEntity(left_shin_entity);
         tech17->AddChild(left_shin_entity);
 
@@ -413,7 +413,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 0.0f,
                 LIMB_ROTATION_LIMIT);
-        cpShapeSetCollisionType(right_shin_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
+        cpShapeSetCollisionType(right_shin_body->GetShape(), static_cast<cpCollisionType>(CollisionGroup::TECH17));
         physics_system.AddEntity(right_shin_entity);
         tech17->AddChild(right_shin_entity);
 
@@ -456,11 +456,11 @@ namespace tjg {
         exit->AddComponent<Sprite>(exit_sprite);
 
         auto segment = exit->AddComponent<StaticSegment>(physics_system.GetSpace(), a + sf::Vector2f(0, -10), a + sf::Vector2f(0, 10), 20);
-        cpShapeSetCollisionType(segment->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::EXIT));
+        cpShapeSetCollisionType(segment->GetShape(), static_cast<cpCollisionType>(CollisionGroup::EXIT));
         exit->AddComponent<SensorShape>(segment->GetShape(), [&](cpShape *shape){
             // Check if Tech17's chest overlaps with the exit door
-            if (cpShapeGetCollisionType(shape) == static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17)) {
-                event_manager.Fire<ExitReached>();
+            if (cpShapeGetCollisionType(shape) == static_cast<cpCollisionType>(CollisionGroup::TECH17)) {
+                event_manager.Fire<ReachedExit>();
             }
         });
         physics_system.AddEntity(exit);

--- a/src/EntityFactory.cpp
+++ b/src/EntityFactory.cpp
@@ -121,7 +121,7 @@ namespace tjg {
                 sf::Vector2f(0, 0),
                 1,
                 sf::Vector2f(CHEST_WIDTH, CHEST_HEIGHT));
-        cpShapeSetCollisionType(torso_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17_CHEST));
+        cpShapeSetCollisionType(torso_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
         physics_system.AddEntity(tech17);
 
         //
@@ -150,6 +150,7 @@ namespace tjg {
                 LIMB_STIFFNESS * 10.0f,
                 0.0f,
                 LIMB_ROTATION_LIMIT);
+        cpShapeSetCollisionType(abs_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
         physics_system.AddEntity(abs_entity);
         tech17->AddChild(abs_entity);
 
@@ -179,6 +180,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 0.0f,
                 LIMB_ROTATION_LIMIT);
+        cpShapeSetCollisionType(head_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
         physics_system.AddEntity(head_entity);
         tech17->AddChild(head_entity);
 
@@ -211,6 +213,7 @@ namespace tjg {
                 // Set the angle to keep the arm at his side.
                 -1 * ARM_ANGLE,
                 LIMB_ROTATION_LIMIT);
+        cpShapeSetCollisionType(left_bicep_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
         physics_system.AddEntity(left_bicep_entity);
         tech17->AddChild(left_bicep_entity);
 
@@ -236,6 +239,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 ARM_ANGLE,
                 LIMB_ROTATION_LIMIT);
+        cpShapeSetCollisionType(right_bicep_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
         physics_system.AddEntity(right_bicep_entity);
         tech17->AddChild(right_bicep_entity);
 
@@ -267,6 +271,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 -1 * ARM_ANGLE / 2.0f,
                 LIMB_ROTATION_LIMIT);
+        cpShapeSetCollisionType(left_forearm_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
         physics_system.AddEntity(left_forearm_entity);
         tech17->AddChild(left_forearm_entity);
 
@@ -292,6 +297,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 ARM_ANGLE / 2.0f,
                 LIMB_ROTATION_LIMIT);
+        cpShapeSetCollisionType(right_forearm_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
         physics_system.AddEntity(right_forearm_entity);
         tech17->AddChild(right_forearm_entity);
 
@@ -322,6 +328,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 0.0f,
                 LIMB_ROTATION_LIMIT);
+        cpShapeSetCollisionType(left_thigh_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
         physics_system.AddEntity(left_thigh_entity);
         tech17->AddChild(left_thigh_entity);
 
@@ -347,6 +354,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 0.0f,
                 LIMB_ROTATION_LIMIT);
+        cpShapeSetCollisionType(right_thigh_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
         physics_system.AddEntity(right_thigh_entity);
         tech17->AddChild(right_thigh_entity);
 
@@ -378,6 +386,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 0.0f,
                 LIMB_ROTATION_LIMIT);
+        cpShapeSetCollisionType(left_shin_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
         physics_system.AddEntity(left_shin_entity);
         tech17->AddChild(left_shin_entity);
 
@@ -403,6 +412,7 @@ namespace tjg {
                 LIMB_STIFFNESS,
                 0.0f,
                 LIMB_ROTATION_LIMIT);
+        cpShapeSetCollisionType(right_shin_body->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17));
         physics_system.AddEntity(right_shin_entity);
         tech17->AddChild(right_shin_entity);
 
@@ -444,11 +454,11 @@ namespace tjg {
         exit_sprite.setTextureRect(sf::IntRect(0, 0, 128, 240));
         exit->AddComponent<Sprite>(exit_sprite);
 
-        auto segment = exit->AddComponent<StaticSegment>(physics_system.GetSpace(), a + sf::Vector2f(0, -60), a + sf::Vector2f(0, 60), 75);
+        auto segment = exit->AddComponent<StaticSegment>(physics_system.GetSpace(), a + sf::Vector2f(0, -10), a + sf::Vector2f(0, 10), 20);
         cpShapeSetCollisionType(segment->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::EXIT));
         exit->AddComponent<SensorShape>(segment->GetShape(), [&](cpShape *shape){
             // Check if Tech17's chest overlaps with the exit door
-            if (cpShapeGetCollisionType(shape) == static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17_CHEST)) {
+            if (cpShapeGetCollisionType(shape) == static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17)) {
                 event_manager.Fire<ExitReached>();
             }
         });

--- a/src/EntityFactory.cpp
+++ b/src/EntityFactory.cpp
@@ -11,7 +11,8 @@ namespace tjg {
         wall_location->SetRotation(calculateAngle(a, b));
 
         // Add static segment component
-        wall->AddComponent<StaticSegment>(physics_system.GetSpace(), a.x, a.y, b.x, b.y, width);
+        auto static_segment = wall->AddComponent<StaticSegment>(physics_system.GetSpace(), a.x, a.y, b.x, b.y, width);
+        cpShapeSetCollisionType(static_segment->GetShape(), static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::WALL));
 
         // Load wall texture.
         auto wall_texture = resource_manager.LoadTexture("wall-texture.png"); // TODO get a real wall texture

--- a/src/Events/ExitReached.cpp
+++ b/src/Events/ExitReached.cpp
@@ -1,7 +1,0 @@
-#include "Events/ExitReached.h"
-
-namespace tjg {
-
-    ExitReached::ExitReached() = default;
-
-}

--- a/src/Events/HitWall.cpp
+++ b/src/Events/HitWall.cpp
@@ -1,0 +1,7 @@
+#include "Events/HitWall.h"
+
+namespace tjg {
+
+    HitWall::HitWall() = default;
+
+}

--- a/src/Events/ReachedExit.cpp
+++ b/src/Events/ReachedExit.cpp
@@ -1,0 +1,7 @@
+#include "Events/ReachedExit.h"
+
+namespace tjg {
+
+    ReachedExit::ReachedExit() = default;
+
+}

--- a/src/Systems/PhysicsSystem.cpp
+++ b/src/Systems/PhysicsSystem.cpp
@@ -4,12 +4,28 @@
 
 namespace tjg {
 
-    PhysicsSystem::PhysicsSystem() : space(cpSpaceNew()) {
+    PhysicsSystem::PhysicsSystem(EventManager &event_manager) :
+            space(cpSpaceNew()),
+            event_manager(event_manager)
+    {
         // Set zero gravity
         cpSpaceSetGravity(space, cpvzero);
 
         // Set some friction
         cpSpaceSetDamping(space, 0.9);
+
+        auto wall_collision_handler = cpSpaceAddCollisionHandler(
+                space,
+                static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17),
+                static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::WALL)
+        );
+
+        wall_collision_handler->beginFunc = [&](cpArbiter *arb, struct cpSpace *space, cpDataPointer data) -> cpBool {
+            event_manager.Fire<ExitReached>();
+            std::cout << "bumped the wall" << std::endl;
+            return cpTrue;
+        };
+
     }
 
     PhysicsSystem::~PhysicsSystem() {

--- a/src/Systems/PhysicsSystem.cpp
+++ b/src/Systems/PhysicsSystem.cpp
@@ -1,12 +1,12 @@
 
-#include <iostream>
 #include "Systems/PhysicsSystem.h"
 
 namespace tjg {
 
     PhysicsSystem::PhysicsSystem(EventManager &event_manager) :
             space(cpSpaceNew()),
-            event_manager(event_manager)
+            event_manager(event_manager),
+            collision_center(space)
     {
         // Set zero gravity
         cpSpaceSetGravity(space, cpvzero);
@@ -14,17 +14,16 @@ namespace tjg {
         // Set some friction
         cpSpaceSetDamping(space, 0.9);
 
-        auto wall_collision_handler = cpSpaceAddCollisionHandler(
-                space,
-                static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::TECH17),
-                static_cast<cpCollisionType>(PhysicsSystem::CollisionGroup::WALL)
-        );
-
-        wall_collision_handler->beginFunc = [&](cpArbiter *arb, struct cpSpace *space, cpDataPointer data) -> cpBool {
-            event_manager.Fire<ExitReached>();
-            std::cout << "bumped the wall" << std::endl;
-            return cpTrue;
-        };
+        // Create a collision center handler that will fire an event when TECH17 hits a wall.
+        collision_center.AddHandler(
+            CollisionGroup::TECH17,
+            CollisionGroup::WALL,
+            [&](cpArbiter *arb, cpSpace *space) -> cpBool {
+                (void)arb;
+                (void)space;
+                event_manager.Fire<HitWall>();
+                return cpTrue;
+            });
 
     }
 

--- a/src/View.cpp
+++ b/src/View.cpp
@@ -16,9 +16,14 @@ namespace tjg {
         entrance = entity_factory.MakeEntrance(sf::Vector2f(0, 0));
         exit = entity_factory.MakeExit(sf::Vector2f(1000, 1000));
 
-        event_manager.RegisterListener<ExitReached>([&](ExitReached &event){
+        event_manager.RegisterListener<ReachedExit>([&](ReachedExit &event){
             (void)event;
             did_exit = true;
+        });
+
+        event_manager.RegisterListener<HitWall>([&](HitWall &event){
+            (void)event;
+            std::cout << "TECH17 just died." << std::endl;
         });
 
         // Create boundary walls using the entity factory.

--- a/src/View.cpp
+++ b/src/View.cpp
@@ -4,6 +4,7 @@
 namespace tjg {
     View::View(ResourceManager &resource_manager) :
             resource_manager(resource_manager),
+            physics_system(event_manager),
             entity_factory(resource_manager, physics_system, event_manager) {
     }
 


### PR DESCRIPTION
This sets up a framework we can use for detecting tech17<->wall collisions, and anything else we need to later.

Currently it just displays a message in the console when the tech17 bumps the wall, but it demonstrates usage of collisioncenter and how it can be tied into the event manager.