### PR TITLE
Relocate CollisionCenter to View

### DIFF
--- a/include/Systems/PhysicsSystem.h
+++ b/include/Systems/PhysicsSystem.h
@@ -28,15 +28,12 @@ namespace tjg {
     class PhysicsSystem : public System {
     private:
         cpSpace* space;
-        EventManager &event_manager;
 
         std::vector<std::shared_ptr<Entity>> entities;
 
-        CollisionCenter collision_center;
-
     public:
         // Constructor
-        PhysicsSystem(EventManager &event_manager);
+        PhysicsSystem();
         // Destructor
         ~PhysicsSystem();
 

--- a/include/View.h
+++ b/include/View.h
@@ -23,6 +23,7 @@ namespace tjg {
         // All views need a physical center and control center.
         PhysicsSystem physics_system;
         ControlCenter control_center;
+        CollisionCenter collision_center;
 
         EntityFactory entity_factory;
         EventManager event_manager;

--- a/src/Systems/PhysicsSystem.cpp
+++ b/src/Systems/PhysicsSystem.cpp
@@ -3,27 +3,14 @@
 
 namespace tjg {
 
-    PhysicsSystem::PhysicsSystem(EventManager &event_manager) :
-            space(cpSpaceNew()),
-            event_manager(event_manager),
-            collision_center(space)
+    PhysicsSystem::PhysicsSystem() :
+            space(cpSpaceNew())
     {
         // Set zero gravity
         cpSpaceSetGravity(space, cpvzero);
 
         // Set some friction
         cpSpaceSetDamping(space, 0.7);
-
-        // Create a collision center handler that will fire an event when TECH17 hits a wall.
-        collision_center.AddHandler(
-            CollisionGroup::TECH17,
-            CollisionGroup::WALL,
-            [&](cpArbiter *arb, cpSpace *space) -> cpBool {
-                (void)arb;
-                (void)space;
-                event_manager.Fire<HitWall>();
-                return cpTrue;
-            });
 
     }
 

--- a/src/View.cpp
+++ b/src/View.cpp
@@ -4,7 +4,8 @@
 namespace tjg {
     View::View(ResourceManager &resource_manager) :
             resource_manager(resource_manager),
-            physics_system(event_manager),
+            physics_system(),
+            collision_center(physics_system.GetSpace()),
             entity_factory(resource_manager, physics_system, event_manager) {
     }
 
@@ -51,6 +52,18 @@ namespace tjg {
         fans.push_back(entity_factory.MakeFan(sf::Vector2f(-1000, 600), sf::Vector2f(-1000, -600), 200, 250.0f, 0.f));
         // Top fan near exit.
         fans.push_back(entity_factory.MakeFan(sf::Vector2f(-1300, -600), sf::Vector2f(-1300, 600), 200, 300.0f, 0.f));
+
+        // Create a collision center handler that will fire a HitWall event when TECH17 hits a wall.
+        collision_center.AddHandler(
+            CollisionGroup::TECH17,
+            CollisionGroup::WALL,
+            [&](cpArbiter *arb, cpSpace *space) -> cpBool {
+                (void)arb;
+                (void)space;
+                event_manager.Fire<HitWall>();
+                return cpTrue;
+            }
+        );
 
         // Call specific view's initialization method.
         initialize();


### PR DESCRIPTION
As discussed, the collision center needs to be located in the View (which will soon be renamed to Logic), per our software architecture diagram