### PR TITLE
Do not build gason executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,10 +60,11 @@ add_subdirectory(lib/Chipmunk2D)
 include_directories(lib/Chipmunk2D/include/chipmunk)
 link_libraries(chipmunk)
 
-############
+#############
 # Add gason #
-############
+#############
 add_subdirectory(lib/gason)
+set_target_properties(test-suite gasonpp benchmark PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
 include_directories(lib/gason/src)
 link_libraries(gason)
 


### PR DESCRIPTION
The gason benchmark suite has a dependency on rapidjson that was causing the build to fail outside of CLion. This line will prevent the gason executables from being built.