### PR TITLE
stop oxygen consumption while paused

### DIFF
--- a/include/Events/FuelExpired.h
+++ b/include/Events/FuelExpired.h
@@ -8,7 +8,7 @@ namespace tjg {
     class FuelExpired : public Event {
 
     public:
-        explicit FuelExpired();
+        explicit FuelExpired() = default;
     };
 }
 

--- a/include/Events/HitWall.h
+++ b/include/Events/HitWall.h
@@ -8,7 +8,7 @@ namespace tjg {
     private:
         //  - time elapsed
     public:
-        explicit HitWall();
+        explicit HitWall() = default;
     };
 }
 

--- a/include/Events/OxygenExpired.h
+++ b/include/Events/OxygenExpired.h
@@ -7,7 +7,7 @@ namespace tjg {
     class OxygenExpired : public Event {
            
     public:
-        explicit OxygenExpired();
+        explicit OxygenExpired() = default;
         // trigger intermediate menu
     };
 }

--- a/include/Events/ReachedExit.h
+++ b/include/Events/ReachedExit.h
@@ -11,7 +11,7 @@ namespace tjg {
         //  - time elapsed
         //  - fuel remaining
     public:
-        explicit ReachedExit();
+        explicit ReachedExit() = default;
     };
 }
 

--- a/include/Events/ViewChanged.h
+++ b/include/Events/ViewChanged.h
@@ -1,0 +1,23 @@
+
+#ifndef GAME_VIEWCHANGED_H
+#define GAME_VIEWCHANGED_H
+
+
+#include "Constants.h"
+#include "Event.h"
+
+namespace tjg {
+    class ViewChanged : public Event {
+    private:
+        ViewSwitch view_switch;
+
+    public:
+        explicit ViewChanged(ViewSwitch view_switch) : view_switch(view_switch) {};
+        ViewSwitch GetViewSwitch() {
+            return view_switch;
+        }
+    };
+}
+
+
+#endif //GAME_VIEWCHANGED_H

--- a/include/Game.h
+++ b/include/Game.h
@@ -19,8 +19,9 @@ namespace tjg {
         void Run();
     private:
         ResourceManager resource_manager;
+        EventManager event_manager;
         LogicCenter logic_center;
-        ViewManager view_manager;        
+        ViewManager view_manager;
         sf::Clock update_clock;
     };
 }

--- a/include/LogicCenter.h
+++ b/include/LogicCenter.h
@@ -8,12 +8,14 @@
 #include "Systems/ControlCenter.h"
 #include "EntityFactory.h"
 #include "EventManager.h"
-#include "Events/ReachedExit.h"
-#include "Constants.h"
-#include "Events/OxygenExpired.h"
 #include "Events/FuelExpired.h"
+#include "Events/OxygenExpired.h"
+#include "Events/ReachedExit.h"
+#include "Events/ViewChanged.h"
+#include "Constants.h"
 #include "Components/FiniteResource.h"
 #include "Level.h"
+
 
 namespace tjg {
 
@@ -29,7 +31,7 @@ namespace tjg {
         EntityFactory entity_factory;
 
         // Event manager
-        EventManager event_manager;
+        EventManager &event_manager;
 
         // Entities
         std::shared_ptr<Entity> tech17;
@@ -44,13 +46,10 @@ namespace tjg {
         std::vector<std::shared_ptr<Entity>> walls;
         std::vector<std::shared_ptr<Entity>> fans;
 
-        // Countdown timer set
-        sf::Clock oxygen_clock;
-
         Level level;
 
     public:
-        LogicCenter(ResourceManager &resource_manager);
+        LogicCenter(ResourceManager &resource_manager, EventManager &event_manager);
 
         /**
          * Initialize creates and configures necessary entities before the game begins

--- a/include/Systems/DialogueSystem.h
+++ b/include/Systems/DialogueSystem.h
@@ -1,6 +1,7 @@
 #ifndef GAME_DIALOGUESYSTEM_H
 #define GAME_DIALOGUESYSTEM_H
 
+#include <limits.h>
 #include <vector>
 #include <string>
 #include <SFML/System/Time.hpp>

--- a/include/ViewManager.h
+++ b/include/ViewManager.h
@@ -15,6 +15,7 @@ namespace tjg {
     class ViewManager {
     private:
         LogicCenter &logic_center;
+        EventManager &event_manager;
         State state;
         sf::RenderWindow window;
         MainMenuView main_menu_view;
@@ -25,18 +26,19 @@ namespace tjg {
 
         bool running = true;
 
-    public:
-        explicit ViewManager(ResourceManager &resource_manager, LogicCenter &logic_center);
-        void Initialize();
-        bool Running();
-        void Update(sf::Time elapsed);
-        void Render();
-        void SwitchView(ViewSwitch view_switch);
         void SwitchToMainMenuView();
         void SwitchToLevelMenuView();
         void SwitchToPauseMenuView(ViewSwitch view_switch);
         void SwitchToPlayerView(unsigned int level_number);
         void ResumePlayerView();
+
+    public:
+        explicit ViewManager(ResourceManager &resource_manager, LogicCenter &logic_center, EventManager &event_manager);
+        void Initialize();
+        bool Running();
+        void Update(sf::Time elapsed);
+        void Render();
+        void SwitchView(ViewSwitch view_switch);
         void HandleWindowEvents(View &current_view);
     };
 }

--- a/src/Events/FuelExpired.cpp
+++ b/src/Events/FuelExpired.cpp
@@ -1,7 +1,0 @@
-#include "Events/FuelExpired.h"
-
-namespace tjg {
-
-    FuelExpired::FuelExpired() = default;
-
-}

--- a/src/Events/HitWall.cpp
+++ b/src/Events/HitWall.cpp
@@ -1,7 +1,0 @@
-#include "Events/HitWall.h"
-
-namespace tjg {
-
-    HitWall::HitWall() = default;
-
-}

--- a/src/Events/OxygenExpired.cpp
+++ b/src/Events/OxygenExpired.cpp
@@ -1,7 +1,0 @@
-#include "Events/OxygenExpired.h"
-
-namespace tjg {
-
-    OxygenExpired::OxygenExpired() = default;
-
-}

--- a/src/Events/ReachedExit.cpp
+++ b/src/Events/ReachedExit.cpp
@@ -1,7 +1,0 @@
-#include "Events/ReachedExit.h"
-
-namespace tjg {
-
-    ReachedExit::ReachedExit() = default;
-
-}

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -6,8 +6,8 @@ namespace tjg {
     Game::Game() :
             // Set the default search folder to "media"
             resource_manager("media"),
-            logic_center(resource_manager),
-            view_manager(resource_manager, logic_center){}
+            logic_center(resource_manager, event_manager),
+            view_manager(resource_manager, logic_center, event_manager){}
 
     // Teardown.
     Game::~Game() = default;
@@ -15,7 +15,7 @@ namespace tjg {
     // Begin the game loop.
     void Game::Run() {
         view_manager.Initialize();
-        view_manager.SwitchToMainMenuView();
+        view_manager.SwitchView(ViewSwitch{State::MAIN_MENU, 0});
 
         while (view_manager.Running()) {
             // Update the logic and handle input 60 times per second

--- a/src/LogicCenter.cpp
+++ b/src/LogicCenter.cpp
@@ -1,10 +1,12 @@
 #include "LogicCenter.h"
 
 namespace tjg {
-    LogicCenter::LogicCenter(ResourceManager &resource_manager) :
+    LogicCenter::LogicCenter(ResourceManager &resource_manager, EventManager &event_manager) :
             physics_system(),
             collision_center(physics_system.GetSpace()),
-            entity_factory(resource_manager, physics_system) {
+            entity_factory(resource_manager, physics_system),
+            event_manager(event_manager)
+    {
     }
 
     void LogicCenter::Initialize(const unsigned int level_number) {
@@ -85,10 +87,8 @@ namespace tjg {
         physics_system.Update(elapsed);
 
         // Countdown timer - start counting. To be more fair, do not start to count during initialization.
-        auto elapsed_seconds = oxygen_clock.getElapsedTime().asSeconds();
         auto oxygen_finite_resource = oxygen_tracker->GetComponent<FiniteResource>();
-        auto max_oxygen = oxygen_finite_resource->GetMaxLevel();
-        oxygen_finite_resource->SetCurrentLevel(max_oxygen - elapsed_seconds);
+        oxygen_finite_resource->ExpendResource(elapsed.asSeconds());
 
         // If out of oxygen, fire an event.
         if (oxygen_finite_resource->IsDepleted()){
@@ -109,7 +109,6 @@ namespace tjg {
         physics_system.Reset();
         collision_center.Reset(physics_system.GetSpace());
         game_state = State::PLAYING;
-        oxygen_clock.restart();
     }
 
 

--- a/src/ViewManager.cpp
+++ b/src/ViewManager.cpp
@@ -1,8 +1,9 @@
 #include "ViewManager.h"
 
 namespace tjg {
-    ViewManager::ViewManager(ResourceManager &resource_manager, LogicCenter &logic_center):
+    ViewManager::ViewManager(ResourceManager &resource_manager, LogicCenter &logic_center, EventManager &event_manager):
         logic_center(logic_center),
+        event_manager(event_manager),
         state(State::MAIN_MENU),
         window(sf::VideoMode(WINDOW_WIDTH, WINDOW_HEIGHT, 32), "Game", sf::Style::Titlebar | sf::Style::Close),
         main_menu_view(resource_manager, window),
@@ -24,6 +25,7 @@ namespace tjg {
 
 
     void ViewManager::SwitchView(ViewSwitch view_switch) {
+        event_manager.Fire<ViewChanged>(view_switch);
         switch (view_switch.state) {
             case State::MAIN_MENU:
                 SwitchToMainMenuView();
@@ -153,7 +155,6 @@ namespace tjg {
 
     void ViewManager::HandleWindowEvents(View &current_view) {
         sf::Event event;
-        ViewSwitch view_switch;
         // Look for window events.
         while (window.pollEvent(event)) {
             switch (event.type) {
@@ -162,8 +163,10 @@ namespace tjg {
                     running = false;
                     break;
                 default:
-                    view_switch = current_view.HandleWindowEvents(event);
-                    SwitchView(view_switch);
+                    auto view_switch = current_view.HandleWindowEvents(event);
+                    if (view_switch.state != State::CONTINUE) {
+                        SwitchView(view_switch);
+                    }
                     break;
             }
         }


### PR DESCRIPTION
This fixes issue #72 as well as introduces an event that is fired whenever the ViewManager is switched. In order to do this, I had to relocate the event_manager object to Game.cpp so that a reference can be given to the ViewManager as well as the LogicCenter.

Note that stopping the oxygen timer does not make use of the new Event I created. In fact nothing does at the moment. I think this was one of the events we discussed having, and I believe can come in useful soon for other purposes.

Some other slight changes:
- Made the various SwitchToXView methods private as I don't think there should multiple exposed ways to change the view as this could cause confusion.
- deleted all of the Events' cpp files because they were all just default constructors.
- included "limits.h" for the DialogueSystem which is using INT_MAX