### PR TITLE
Make walls non-lethal by default but add lethal walls as an option

### DIFF
--- a/data/level1.json
+++ b/data/level1.json
@@ -29,11 +29,11 @@
 
   "walls":
   [
-    {"Origin": {"x": -1500, "y": -600}, "Endpoint": {"x": 500, "y": -600}, "Radius": 40 },
+    {"Origin": {"x": -1500, "y": -600}, "Endpoint": {"x": 500, "y": -600}, "Radius": 40},
     {"Origin": {"x": -1500,"y": 600},"Endpoint": {"x": 500,"y": 600},"Radius": 40},
     {"Origin": {"x": -1500,"y": -600},"Endpoint": {"x": -1500,"y": 600},"Radius": 40},
     {"Origin": {"x": 500,"y": -600},"Endpoint": {"x": 500,"y": 600},"Radius": 40},
-    {"Origin": {"x": -800,"y": -600},"Endpoint": {"x": -800,"y": 90},"Radius": 40}
+    {"Origin": {"x": -800,"y": -600},"Endpoint": {"x": -800,"y": 90},"Radius": 40, "Lethal": true}
   ],
 
   "fans":

--- a/include/CollisionCenter.h
+++ b/include/CollisionCenter.h
@@ -14,6 +14,7 @@ namespace tjg {
         DEFAULT = 0,
         TECH17,
         WALL,
+        LETHALWALL,
         EXIT
     };
 

--- a/include/EntityFactory.h
+++ b/include/EntityFactory.h
@@ -47,7 +47,7 @@ namespace tjg {
                 physics_system(physics_system) {}
 
         // Entity factory methods.
-        std::shared_ptr<Entity> MakeWall(const sf::Vector2f &origin_point, const sf::Vector2f &end_point, float radius);
+        std::shared_ptr<Entity> MakeWall(const sf::Vector2f &origin_point, const sf::Vector2f &end_point, float radius, bool lethal = false);
         std::shared_ptr<Entity> MakeStaticSprite(sf::Sprite sprite, const sf::Vector2f &position);
         std::shared_ptr<Entity> MakeTiledBackground(const std::string &texture_path);
         std::shared_ptr<Entity> MakeTech17(const float & tech17_x, const float &tech17_y);

--- a/include/Events/HitLethalWall.h
+++ b/include/Events/HitLethalWall.h
@@ -4,11 +4,11 @@
 #include "Event.h"
 
 namespace tjg {
-    class HitWall : public Event {
+    class HitLethalWall : public Event {
     private:
         //  - time elapsed
     public:
-        explicit HitWall() = default;
+        explicit HitLethalWall() = default;
     };
 }
 

--- a/include/Level.h
+++ b/include/Level.h
@@ -43,13 +43,15 @@ namespace tjg {
 
         struct Wall {
             float origin_x, origin_y, endpoint_x, endpoint_y, radius;
+            bool lethal;
 
-            inline Wall(float origin_x, float origin_y, float endpoint_x, float endpoint_y, float radius) :
+            inline Wall(float origin_x, float origin_y, float endpoint_x, float endpoint_y, float radius, bool lethal) :
                 origin_x(origin_x),
                 origin_y(origin_y),
                 endpoint_x(endpoint_x),
                 endpoint_y(endpoint_y),
-                radius(radius){}
+                radius(radius),
+                lethal(lethal){}
         };
 
         // Constructor innitiate the level class with default entities information without any fans

--- a/include/Systems/PhysicsSystem.h
+++ b/include/Systems/PhysicsSystem.h
@@ -17,7 +17,7 @@
 #include "Components/SensorShape.h"
 
 #include "EventManager.h"
-#include "Events/HitWall.h"
+#include "Events/HitLethalWall.h"
 
 #include "System.h"
 

--- a/src/EntityFactory.cpp
+++ b/src/EntityFactory.cpp
@@ -3,7 +3,7 @@
 
 namespace tjg {
 
-    std::shared_ptr<Entity> EntityFactory::MakeWall(const sf::Vector2f &origin_point, const sf::Vector2f &end_point, const float radius) {
+    std::shared_ptr<Entity> EntityFactory::MakeWall(const sf::Vector2f &origin_point, const sf::Vector2f &end_point, const float radius, const bool lethal) {
         // Create wall entity.
         auto wall = std::make_shared<Entity>();
 
@@ -13,7 +13,7 @@ namespace tjg {
 
         // Add static segment component
         auto static_segment = wall->AddComponent<StaticSegment>(physics_system.GetSpace(), origin_point.x, origin_point.y, end_point.x, end_point.y, radius);
-        cpShapeSetCollisionType(static_segment->GetShape(), static_cast<cpCollisionType>(CollisionGroup::WALL));
+        cpShapeSetCollisionType(static_segment->GetShape(), static_cast<cpCollisionType>(lethal ? CollisionGroup::LETHALWALL : CollisionGroup::WALL));
 
         // Load wall texture.
         auto wall_texture = resource_manager.LoadTexture("white-tile.jpg");
@@ -26,7 +26,7 @@ namespace tjg {
         sf::Sprite wall_sprite;
         wall_sprite.setTexture(*wall_texture);
         wall_sprite.setTextureRect(sf::IntRect(0, 0, (int)(length + radius*2), (int)radius*2));
-        wall_sprite.setColor(sf::Color(150, 150, 150)); // Dark gray
+        wall_sprite.setColor(lethal ? sf::Color(255, 150, 150) : sf::Color(150, 150, 150)); // Dark gray
         wall->AddComponent<Sprite>(wall_sprite);
 
         return wall;

--- a/src/Level.cpp
+++ b/src/Level.cpp
@@ -125,7 +125,9 @@ namespace tjg {
                 static_cast<float>(wall["Origin"]["y"].number_value()),
                 static_cast<float>(wall["Endpoint"]["x"].number_value()),
                 static_cast<float>(wall["Endpoint"]["y"].number_value()),
-                static_cast<float>(wall["Radius"].number_value()));
+                static_cast<float>(wall["Radius"].number_value()),
+                static_cast<bool>(wall["Lethal"].bool_value())
+            );
         }
         walls_.shrink_to_fit();
         

--- a/src/Level.cpp
+++ b/src/Level.cpp
@@ -55,6 +55,7 @@ namespace tjg {
             std::cout << "# [" << ++wall_counter << "] [Origin]" << wall["Origin"].dump() << "\n";
             std::cout << "#     [Endpoint]" << wall["Endpoint"].dump() << "\n";
             std::cout << "#     [radius]: " << wall["Radius"].dump() << "\n";
+            std::cout << "#     [Lethal]: " << wall["Lethal"].dump() << "\n";
         }
 
         std::cout << '#' << std::endl << "##### [dialogues]" << std::endl;

--- a/src/LogicCenter.cpp
+++ b/src/LogicCenter.cpp
@@ -24,7 +24,7 @@ namespace tjg {
             (void)event;
             game_state = State::WON;
         });
-        event_manager.RegisterListener<HitWall>([&](HitWall &event){
+        event_manager.RegisterListener<HitLethalWall>([&](HitLethalWall &event){
             (void)event;
             std::cout << "Hit a wall!" << std::endl;
             game_state = State::FAILED;
@@ -52,7 +52,7 @@ namespace tjg {
 
         //Iterate wall information record from level's walls vector, create walls and add them to the walls vector.
         for (auto wall : level.GetWalls()) {            
-            walls.push_back(entity_factory.MakeWall(sf::Vector2f(wall.origin_x, wall.origin_y), sf::Vector2f(wall.endpoint_x, wall.endpoint_y), wall.radius));
+            walls.push_back(entity_factory.MakeWall(sf::Vector2f(wall.origin_x, wall.origin_y), sf::Vector2f(wall.endpoint_x, wall.endpoint_y), wall.radius, wall.lethal));
         }
                         
         //Iterate fan information record from level's fans vector, create fans and add them to the fans vector.
@@ -60,14 +60,14 @@ namespace tjg {
             fans.push_back(entity_factory.MakeFan(sf::Vector2f(fan.origin_x, fan.origin_y), sf::Vector2f(fan.endpoint_x, fan.endpoint_y), fan.width, fan.origin_strength, fan.endpoint_strength));
         }
 
-        // Create a collision center handler that will fire a HitWall event when TECH17 hits a wall.
+        // Create a collision center handler that will fire a HitLethalWall event when TECH17 hits a wall.
         collision_center.AddHandler(
             CollisionGroup::TECH17,
-            CollisionGroup::WALL,
+            CollisionGroup::LETHALWALL,
             [&](cpArbiter *arb, cpSpace *space) {
                 (void)arb;
                 (void)space;
-                event_manager.Fire<HitWall>();
+                event_manager.Fire<HitLethalWall>();
             }
         );
 


### PR DESCRIPTION
This change allows walls to be bumped into without ending the level, but also adds a "lethal" boolean flag which can be set in the level data file. If set, the wall will be colored reddish to indicate it is lethal, and the collision event will be raised as before.

Eventually we will use a different sprite to indicate these walls are not okay to touch, but for now the red tint conveys the message.

This will close #66