### PR TITLE
Add a velocity to particle systems

### DIFF
--- a/include/Components/Velocity.h
+++ b/include/Components/Velocity.h
@@ -1,0 +1,25 @@
+
+#ifndef GAME_VELOCITY_H
+#define GAME_VELOCITY_H
+
+#include <SFML/Audio.hpp>
+#include "Component.h"
+
+namespace tjg {
+
+    class Velocity : public Component {
+    private:
+        // Fields
+        sf::Vector2f velocity;
+    public:
+        // Constructors
+        Velocity() = default;
+        explicit Velocity(sf::Vector2f velocity);
+        Velocity(float x, float y);
+        // Accessors
+        sf::Vector2f GetVelocity();
+        void SetVelocity(sf::Vector2f velocity);
+    };
+
+}
+#endif //GAME_VELOCITY_H

--- a/include/Systems/ParticleSystem.h
+++ b/include/Systems/ParticleSystem.h
@@ -5,6 +5,7 @@
 #include <random>
 
 #include "Components/Timer.h"
+#include "Components/Velocity.h"
 #include "System.h"
 #include "Systems/SpriteRenderSystem.h"
 
@@ -44,6 +45,8 @@ namespace tjg {
         std::uniform_real_distribution<float> lifetime_dist;
         std::uniform_real_distribution<float> x_position_variation_dist;
         std::uniform_real_distribution<float> y_position_variation_dist;
+        std::uniform_real_distribution<float> x_velocity_variation_dist;
+        std::uniform_real_distribution<float> y_velocity_variation_dist;
         std::uniform_real_distribution<float> angular_velocity_dist;
 
         // Initializes specified particle at position
@@ -72,6 +75,7 @@ namespace tjg {
          * particle will be 50% - 150% of this value.
          * @param position_variation particle will be spawned at a random emitter's location with +-x/+-y added to it's
          * position.
+         * @param velocity_variation particle will be spawned at with velocity +-x/+-y
          * @param angular_velocity_variation particle will be given a random angular velocity between
          * +-angular_velocity_variation.
          * @param color_transformation function which maps the percent_lifetime (given as a value between 0.0 and 1.0)
@@ -87,6 +91,7 @@ namespace tjg {
                        sf::Time particle_rate,
                        sf::Time lifetime,
                        sf::Vector2f position_variation,
+                       sf::Vector2f velocity_variation,
                        float angular_velocity_variation,
                        std::function<sf::Color(float)> color_transformation = [](float x) {
                            (void) x;
@@ -105,7 +110,7 @@ namespace tjg {
         void AddEntity(std::shared_ptr<Entity> entity) override;
 
         // Updates particle properties, respawning as needed
-        void Update();
+        void Update(const sf::Time&);
 
         // Turn the particle system on/off
         void Enable();

--- a/include/Systems/PhysicsParticleSystem.h
+++ b/include/Systems/PhysicsParticleSystem.h
@@ -38,6 +38,7 @@ namespace tjg {
                               sf::Time particle_rate,
                               sf::Time lifetime,
                               sf::Vector2f position_variation,
+                              sf::Vector2f velocity_variation,
                               float angular_velocity_variation,
                               std::function<sf::Color(float)> color_transformation = [](float x) {
                                   (void) x;

--- a/src/Components/Velocity.cpp
+++ b/src/Components/Velocity.cpp
@@ -1,0 +1,17 @@
+
+#include "Components/Velocity.h"
+
+namespace tjg {
+
+    Velocity::Velocity(float x, float y) : velocity(x, y) {}
+    Velocity::Velocity(sf::Vector2f velocity) : velocity(velocity) {}
+
+    void Velocity::SetVelocity(sf::Vector2f velocity) {
+        this->velocity = velocity;
+    }
+
+    sf::Vector2f Velocity::GetVelocity() {
+        return velocity;
+    }
+
+}

--- a/src/Systems/PhysicsParticleSystem.cpp
+++ b/src/Systems/PhysicsParticleSystem.cpp
@@ -11,6 +11,7 @@ namespace tjg {
                                                  sf::Time particle_rate,
                                                  sf::Time lifetime,
                                                  sf::Vector2f position_variation,
+                                                 sf::Vector2f velocity_variation,
                                                  const float angular_velocity_variation,
                                                  std::function<sf::Color(float)> color_transformation,
                                                  std::function<sf::Vector2f(float)> scale_transformation) :
@@ -22,6 +23,7 @@ namespace tjg {
                            particle_rate,
                            lifetime,
                            position_variation,
+                           velocity_variation,
                            angular_velocity_variation,
                            std::move(color_transformation),
                            std::move(scale_transformation)),
@@ -38,6 +40,7 @@ namespace tjg {
                               position.y + y_position_variation_dist(gen)));
         cpBodySetVelocity(body->GetBody(), cpvzero);
         cpBodySetAngularVelocity(body->GetBody(), angular_velocity_dist(gen));
+        cpBodySetVelocity(body->GetBody(), cpv(x_velocity_variation_dist(gen), y_velocity_variation_dist(gen)));
     }
 
     void PhysicsParticleSystem::MakeParticle(const sf::Vector2f position) {

--- a/src/Views/LevelView.cpp
+++ b/src/Views/LevelView.cpp
@@ -7,7 +7,7 @@ namespace tjg {
             logic_center(logic_center),
             dust_particle_system(main_render_system, logic_center.GetPhysicsSystem(), 200,
                                  sf::Sprite(*resource_manager.LoadTexture("dust.png"), sf::IntRect(0, 0, 256, 256)),
-                                 -10, sf::BlendAdd, sf::milliseconds(1), sf::seconds(10), sf::Vector2f(60, 60), 2.0f,
+                                 -10, sf::BlendAdd, sf::milliseconds(1), sf::seconds(10), sf::Vector2f(60, 60), sf::Vector2f(0, 0), 2.0f,
                                  [](float x){
                                      auto alpha = static_cast<sf::Uint8>(std::max(0.0f, static_cast<float>(128 * cos(x * 2.5)+128)));
                                      return sf::Color(128, 128, 255, alpha/sf::Uint8(2));
@@ -18,7 +18,7 @@ namespace tjg {
                                  }),
             jetpack_flame_system(main_render_system, 500,
                                  sf::Sprite(*resource_manager.LoadTexture("dust.png"), sf::IntRect(0, 0, 256, 256)),
-                                 40, sf::BlendAdd, sf::milliseconds(1), sf::seconds(2), sf::Vector2f(0, 0), 0,
+                                 40, sf::BlendAdd, sf::milliseconds(1), sf::seconds(2), sf::Vector2f(0, 0), sf::Vector2f(5, 5), 0,
                                  [](float x){
                                      auto decreasing = static_cast<sf::Uint8>(std::max(0.0f, static_cast<float>(255 * sin(1.0 / 25.0 * (x * 100)))));
                                      auto increasing = sf::Uint8(255) - decreasing;
@@ -139,8 +139,8 @@ namespace tjg {
     // Update logic that is specific to the player view.
     void LevelView::Update(const sf::Time &elapsed) {
         CheckKeys(elapsed);
-        dust_particle_system.Update();
-        jetpack_flame_system.Update();
+        dust_particle_system.Update(elapsed);
+        jetpack_flame_system.Update(elapsed);
         dialogue_system.Update(elapsed);
     }
 


### PR DESCRIPTION
This will be necessary for the shock boxes. 

@crombach unfortunately this will break your current code in the shock-boxes branch. You will need to add an additional sf::Vector2f to the constructor of the shock particle system which specifies the variation in velocity of the particles.