### PR TITLE
Show alerts when resource are running low.

### DIFF
--- a/include/Components/FiniteResource.h
+++ b/include/Components/FiniteResource.h
@@ -17,6 +17,7 @@ namespace tjg {
         // Accessor methods.
         float GetMaxLevel();
         float GetCurrentLevel();
+        float GetPercentRemaining();
         void SetCurrentLevel(float new_level);
         void ExpendResource(float amount);
         bool IsDepleted();

--- a/include/EventManager.h
+++ b/include/EventManager.h
@@ -26,10 +26,9 @@ namespace tjg {
                 listener(event);
             }
 
-            auto once = one_time_listeners[std::type_index(typeid(T))];
-            while (!once.empty()) {
-                once.back()(event);
-                once.pop_back();
+            while (!one_time_listeners[std::type_index(typeid(T))].empty()) {
+                one_time_listeners[std::type_index(typeid(T))].back()(event);
+                one_time_listeners[std::type_index(typeid(T))].pop_back();
             }
         }
 
@@ -46,6 +45,11 @@ namespace tjg {
             one_time_listeners[std::type_index(typeid(T))].push_back([=](Event &e) {
                 f(static_cast<T &>(e));
             });
+        }
+
+        void ClearListeners() {
+            listeners.clear();
+            one_time_listeners.clear();
         }
     };
 }

--- a/include/Events/FuelLow.h
+++ b/include/Events/FuelLow.h
@@ -1,0 +1,17 @@
+#ifndef GAME_FUELLOW_H
+#define GAME_FUELLOW_H
+
+
+#include "Event.h"
+
+namespace tjg {
+
+    class FuelLow : public Event {
+
+    public:
+        explicit FuelLow() = default;
+    };
+}
+
+
+#endif //GAME_FUELLOW_H

--- a/include/Events/OxygenLow.h
+++ b/include/Events/OxygenLow.h
@@ -1,0 +1,17 @@
+#ifndef GAME_OXYGENLOW_H
+#define GAME_OXYGENLOW_H
+
+
+#include "Event.h"
+
+namespace tjg {
+
+    class OxygenLow : public Event {
+    public:
+
+        explicit OxygenLow() = default;
+    };
+}
+
+
+#endif //GAME_OXYGENLOW_H

--- a/include/LogicCenter.h
+++ b/include/LogicCenter.h
@@ -9,7 +9,9 @@
 #include "EntityFactory.h"
 #include "EventManager.h"
 #include "Events/FuelExpired.h"
+#include "Events/FuelLow.h"
 #include "Events/OxygenExpired.h"
+#include "Events/OxygenLow.h"
 #include "Events/ReachedExit.h"
 #include "Events/ViewChanged.h"
 #include "Constants.h"
@@ -80,6 +82,7 @@ namespace tjg {
         EntityFactory& GetEntityFactory();
         ControlCenter& GetControlCenter();
         PhysicsSystem& GetPhysicsSystem();
+        EventManager& GetEventManager();
         std::shared_ptr<Entity> GetTech17();
         std::vector<std::shared_ptr<Entity>>& GetWalls();
         std::vector<std::shared_ptr<Entity>>& GetPressureSources();

--- a/include/Views/LevelView.h
+++ b/include/Views/LevelView.h
@@ -51,6 +51,8 @@ namespace tjg {
         float statusbar_y_padding;
         sf::Vector2f trackers_initial_size;
         sf::Vector2f dialog_initial_size;
+        sf::Clock statusbar_blinker;
+        sf::Time statusbar_blinktime = sf::seconds(0.5);
 
         // Status bar methods.
         void InitializeStatusBar(std::shared_ptr<sf::Font> hud_font);

--- a/src/Components/FiniteResource.cpp
+++ b/src/Components/FiniteResource.cpp
@@ -33,4 +33,8 @@ namespace tjg {
         return current_level <= 0;
     }
 
+    float FiniteResource::GetPercentRemaining() {
+        return current_level/max_level;
+    }
+
 }

--- a/src/LogicCenter.cpp
+++ b/src/LogicCenter.cpp
@@ -114,14 +114,22 @@ namespace tjg {
         // Countdown timer - start counting. To be more fair, do not start to count during initialization.
         auto oxygen_finite_resource = oxygen_tracker->GetComponent<FiniteResource>();
         oxygen_finite_resource->ExpendResource(elapsed.asSeconds());
-
+        // If less than 10% of oxygen remains, fire an event.
+        if (oxygen_finite_resource->GetPercentRemaining() < 0.1f) {
+            event_manager.Fire<OxygenLow>();
+        }
         // If out of oxygen, fire an event.
         if (oxygen_finite_resource->IsDepleted()){
             event_manager.Fire<OxygenExpired>();
         }
 
-        // If out of fuel, fire an event.
+
         auto fuel_finite_resource = fuel_tracker->GetComponent<FiniteResource>();
+        // If less than 10% of fuel remains, fire an event.
+        if (fuel_finite_resource->GetPercentRemaining() < 0.1f) {
+            event_manager.Fire<FuelLow>();
+        }
+        // If out of fuel, fire an event.
         if (fuel_finite_resource->IsDepleted()){
             event_manager.Fire<FuelExpired>();
         }
@@ -129,6 +137,7 @@ namespace tjg {
 
 
     void LogicCenter::Reset() {
+        event_manager.ClearListeners();
         walls.clear();
         pressure_sources.clear();
         fans.clear();
@@ -185,6 +194,10 @@ namespace tjg {
 
     PhysicsSystem& LogicCenter::GetPhysicsSystem() {
         return physics_system;
+    }
+
+    EventManager& LogicCenter::GetEventManager() {
+        return event_manager;
     }
 
     Level& LogicCenter::GetLevel() {

--- a/src/Views/LevelView.cpp
+++ b/src/Views/LevelView.cpp
@@ -113,6 +113,14 @@ namespace tjg {
 
         // Initialize status bar.
         InitializeStatusBar(lcd_regular);
+        logic_center.GetEventManager().RegisterOnce<FuelLow>([&](FuelLow &event){
+            (void)event;
+            dialogue_system.ShowUrgentMessage(Dialogue("Fuel levels critical!", 5));
+        });
+        logic_center.GetEventManager().RegisterOnce<OxygenLow>([&](OxygenLow &event){
+            (void)event;
+            dialogue_system.ShowUrgentMessage(Dialogue("Oxygen levels critical!", 5));
+        });
 
         // Initialize dialog system
         std::vector<Dialogue> dialogues = logic_center.GetLevel().GetDialogues();
@@ -292,6 +300,13 @@ namespace tjg {
     void LevelView::RenderStatusBar() {
         // Draw background elements.
         window.draw(statusbar_background);
+        if (statusbar_blinker.getElapsedTime() > statusbar_blinktime) {
+            auto low_fuel = logic_center.GetFuelTracker()->GetComponent<FiniteResource>()->GetPercentRemaining() < 0.1f;
+            fuel_tank_background.setFillColor(low_fuel ? sf::Color(128 - fuel_tank_background.getFillColor().r, 0, 0, 255) : sf::Color::Black);
+            auto low_oxygen = logic_center.GetOxygenTracker()->GetComponent<FiniteResource>()->GetPercentRemaining() < 0.1f;
+            oxygen_tank_background.setFillColor(low_oxygen ? sf::Color(128 - oxygen_tank_background.getFillColor().r, 0, 0, 255) : sf::Color::Black);
+            statusbar_blinker.restart();
+        }
         window.draw(fuel_tank_background);
         window.draw(oxygen_tank_background);
         window.draw(dialogue_background);


### PR DESCRIPTION
Now there will be a dialogue alert when fuel/oxygen goes below 10%. Additionally, I added a red flashing background for both the status bars.

Also:
- fixes a bug with the event manager "one time" listeners where they weren't actually only firing once as they should have been.
- fix #106 where event listeners were being added each time the level started, but never cleared.

