### PR TITLE
Make the escape key work in all views.

### DIFF
--- a/src/Views/FailMenuView.cpp
+++ b/src/Views/FailMenuView.cpp
@@ -72,6 +72,10 @@ namespace tjg{
                         sound_manager->MenuSelect();
                         sound_manager->StopLoseMusic();
                         return options[selection];
+                    case sf::Keyboard::Escape:
+                        sound_manager->MenuSelect();
+                        sound_manager->StopLoseMusic();
+                        return options[1];
                     default:
                         break;
                 }

--- a/src/Views/FinishMenuView.cpp
+++ b/src/Views/FinishMenuView.cpp
@@ -60,6 +60,10 @@ namespace tjg{
                         sound_manager->MenuSelect();
                         sound_manager->StopWinMusic();
                         return options[selection];
+                    case sf::Keyboard::Escape:
+                        sound_manager->MenuSelect();
+                        sound_manager->StopWinMusic();
+                        return options[0];
                     default:
                         break;
                 }

--- a/src/Views/MainMenuView.cpp
+++ b/src/Views/MainMenuView.cpp
@@ -90,6 +90,9 @@ namespace tjg {
                             RenderAnimation();
                         }
                         return options[selection];
+                    case sf::Keyboard::Escape:
+                        sound_manager->MenuSelect();
+                        return options[1];
                     default:
                         break;
                 }

--- a/src/Views/PauseMenuView.cpp
+++ b/src/Views/PauseMenuView.cpp
@@ -90,6 +90,12 @@ namespace tjg{
                             sound_manager->ClearSpatialSounds();
                         }
                         return options[selection];
+                    case sf::Keyboard::Escape:
+                        sound_manager->MenuSelect();
+                        sound_manager->StopLevelMusic();
+                        sound_manager->StopSpatialSounds();
+                        sound_manager->ClearSpatialSounds();
+                        return options[1];
                     default:
                         break;
                 }

--- a/src/Views/PauseMenuView.cpp
+++ b/src/Views/PauseMenuView.cpp
@@ -91,11 +91,10 @@ namespace tjg{
                         }
                         return options[selection];
                     case sf::Keyboard::Escape:
-                        sound_manager->MenuSelect();
-                        sound_manager->StopLevelMusic();
-                        sound_manager->StopSpatialSounds();
-                        sound_manager->ClearSpatialSounds();
-                        return options[1];
+                        sound_manager->StopMenuMusic();
+                        sound_manager->StartLevelMusic();
+                        sound_manager->StartSpatialSounds();
+                        return options[0];
                     default:
                         break;
                 }

--- a/src/Views/WinMenuView.cpp
+++ b/src/Views/WinMenuView.cpp
@@ -90,6 +90,10 @@ namespace tjg{
                         sound_manager->MenuSelect();
                         sound_manager->StopWinMusic();
                         return options[selection];
+                    case sf::Keyboard::Escape:
+                        sound_manager->MenuSelect();
+                        sound_manager->StopWinMusic();
+                        return options[2];
                     default:
                         break;
                 }


### PR DESCRIPTION
This makes it so the escape key will bring you back to the main menu when pressed from a win/lose screen. Also makes it so if pressed at the main menu, the game will close.

Close #97